### PR TITLE
UI and Cluster History Overhaul

### DIFF
--- a/client/app.jsx
+++ b/client/app.jsx
@@ -6,6 +6,7 @@ import LandingPage from "./containers/landing-page-container";
 import NotFound from "./containers/NotFound";
 import Navbar from "./components/nav-bar";
 import Auth from "./containers/auth";
+import Footer from "./components/footer";
 import "./static/styles.css";
 
 function App() {
@@ -114,17 +115,20 @@ function App() {
 
   return (
     <NavbarContext.Provider value={providerValue}>
-      <Navbar navigate={navigate} logUserOut={logUserOut} />
-      <Routes>
-        <Route path="*" element={<NotFound />} />
-        <Route
-          exact
-          path="/dashboard"
-          element={loggedIn ? <DashboardContainer /> : <Navigate to="/" />}
-        />
-        <Route exact path="/auth" element={<Auth navigate={navigate} />} />
-        <Route exact path="/" element={<LandingPage navigate={navigate} />} />
-      </Routes>
+      <main className="flex flex-col min-h-screen">
+        <Navbar navigate={navigate} logUserOut={logUserOut} />
+        <Routes>
+          <Route path="*" element={<NotFound />} />
+          <Route
+            exact
+            path="/dashboard"
+            element={loggedIn ? <DashboardContainer /> : <Navigate to="/" />}
+          />
+          <Route exact path="/auth" element={<Auth navigate={navigate} />} />
+          <Route exact path="/" element={<LandingPage navigate={navigate} />} />
+        </Routes>
+      </main>
+      <Footer />
     </NavbarContext.Provider>
   );
 }

--- a/client/components/aggregated-chart.jsx
+++ b/client/components/aggregated-chart.jsx
@@ -1,0 +1,87 @@
+import React, { useContext } from "react";
+import { NavbarContext } from "../NavbarContext";
+import "chart.js/auto";
+import { Bar, Line } from "react-chartjs-2";
+
+const AggregatedChart = (props) => {
+  // selecting metric specific to this chart
+  const metric = props.metricSelection;
+  const chartData = props.chartData[metric];
+
+  const data = chartData.info;
+
+  const { user } = useContext(NavbarContext).userState;
+  console.log("chartData: ", user.metric);
+  const connCountArr = [];
+  const labels = [];
+  for (let i = 0; i < user.metric.length; i++) {
+    labels.push(i);
+    connCountArr.push({
+      x: i,
+      y: user.metric[i].active_connection_count.metrics[0].value
+    });
+  }
+  console.log("connCountArr: ", connCountArr);
+  console.log("data: ", data);
+  const data2 = {
+    labels: labels,
+    datasets: [
+      {
+        data: connCountArr
+      }
+    ]
+  };
+
+  const { setMetric } = useContext(NavbarContext).metricState;
+  const { sideBarMode } = useContext(NavbarContext).sideBarState;
+
+  async function updateMetrics() {
+    const response = await fetch("/api/metric");
+    const metric = await response.json();
+
+    setMetric(metric);
+  }
+
+  return (
+    <div className="topic-chart font-mono chart-container pb-10">
+      <p style={{ fontSize: "18px" }}>{chartData.colDescription}</p>
+
+      <br />
+      <Line
+        type={"line"}
+        options={{
+          maintainAspectRatio: false
+        }}
+        data={data2}
+      />
+      <Bar
+        width={"20%"}
+        type={"bar"}
+        data={data}
+        options={{
+          maintainAspectRatio: false
+        }}
+      />
+      <br />
+      {chartData.compositeChart && (
+        <>
+          <p className="chart-total">
+            {chartData.totalDescription1} <span>{chartData.totalValue1}</span>
+          </p>
+          <p className="chart-total">
+            {chartData.totalDescription2} <span>{chartData.totalValue2}</span>
+          </p>
+        </>
+      )}
+
+      {!chartData.compositeChart && (
+        <p className="chart-total">
+          {chartData.totalDescription}
+          <span>{chartData.totalValue}</span>
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default AggregatedChart;

--- a/client/components/aggregated-chart.jsx
+++ b/client/components/aggregated-chart.jsx
@@ -4,34 +4,7 @@ import "chart.js/auto";
 import { Bar, Line } from "react-chartjs-2";
 
 const AggregatedChart = (props) => {
-  // selecting metric specific to this chart
-  const metric = props.metricSelection;
-  const chartData = props.chartData[metric];
-
-  const data = chartData.info;
-
-  const { user } = useContext(NavbarContext).userState;
-  console.log("chartData: ", user.metric);
-  const connCountArr = [];
-  const labels = [];
-  for (let i = 0; i < user.metric.length; i++) {
-    labels.push(i);
-    connCountArr.push({
-      x: i,
-      y: user.metric[i].active_connection_count.metrics[0].value
-    });
-  }
-  console.log("connCountArr: ", connCountArr);
-  console.log("data: ", data);
-  const data2 = {
-    labels: labels,
-    datasets: [
-      {
-        data: connCountArr
-      }
-    ]
-  };
-
+  //metric selection and context state
   const { setMetric } = useContext(NavbarContext).metricState;
   const { sideBarMode } = useContext(NavbarContext).sideBarState;
 
@@ -42,46 +15,76 @@ const AggregatedChart = (props) => {
     setMetric(metric);
   }
 
-  return (
-    <div className="topic-chart font-mono chart-container pb-10">
-      <p style={{ fontSize: "18px" }}>{chartData.colDescription}</p>
+  // selecting metric specific to this chart
+  const metric = props.metricSelection;
+  const chartData = props.chartData[metric];
 
-      <br />
-      <Line
-        type={"line"}
-        options={{
-          maintainAspectRatio: false
-        }}
-        data={data2}
-      />
-      <Bar
-        width={"20%"}
-        type={"bar"}
-        data={data}
-        options={{
-          maintainAspectRatio: false
-        }}
-      />
-      <br />
-      {chartData.compositeChart && (
-        <>
-          <p className="chart-total">
-            {chartData.totalDescription1} <span>{chartData.totalValue1}</span>
-          </p>
-          <p className="chart-total">
-            {chartData.totalDescription2} <span>{chartData.totalValue2}</span>
-          </p>
-        </>
-      )}
+  const data = chartData.info;
 
-      {!chartData.compositeChart && (
-        <p className="chart-total">
-          {chartData.totalDescription}
-          <span>{chartData.totalValue}</span>
-        </p>
-      )}
-    </div>
-  );
+  const { user } = useContext(NavbarContext).userState;
+  console.log("chartData: ", user.metric);
+  //object with all statistics for user clusters
+  const rawMetric = user.metric;
+
+  //stats for aggregated charts
+  const aggStats = {
+    active_connection_count: "",
+    partition_count: "",
+    successful_authentication_count: "",
+    cluster_load_percent: ""
+  };
+
+  //dataset creation for charts
+  for (const stat in aggStats) {
+    const data = { labels: [], datasets: [] };
+    let statArr = [];
+    const labels = [];
+    let curr = rawMetric[0].clusterId;
+    for (let i = 0; i < rawMetric.length; i++) {
+      data.labels.push(rawMetric[i].created_at);
+      statArr.push({
+        x: i,
+        //edge case where some of the arrays were empty
+        y: rawMetric[i][stat].metrics.length
+          ? rawMetric[i][stat].metrics[0].value
+          : 0
+      });
+      if (i + 1 === rawMetric.length || rawMetric[i + 1].clusterId !== curr) {
+        const metricObj = { label: curr, data: statArr };
+        data.labels.sort();
+        data.datasets.push(metricObj);
+        if (i + 1 !== rawMetric.length) {
+          statArr = [];
+          curr = rawMetric[i + 1].clusterId;
+        }
+      }
+    }
+    aggStats[stat] = data;
+  }
+
+  console.log("data: ", aggStats);
+
+  //creating aggregated charts
+  const charts = [];
+  for (const stat in aggStats) {
+    const chart = (
+      <div className="topic-chart font-mono chart-container pb-10">
+        <p style={{ fontSize: "18px" }}>{stat}</p>
+
+        <br />
+        <Line
+          type={"line"}
+          options={{
+            maintainAspectRatio: false
+          }}
+          data={aggStats[stat]}
+        />
+      </div>
+    );
+    charts.push(chart);
+  }
+
+  return <>{charts}</>;
 };
 
 export default AggregatedChart;

--- a/client/components/aggregated-chart.jsx
+++ b/client/components/aggregated-chart.jsx
@@ -22,16 +22,18 @@ const AggregatedChart = (props) => {
   const data = chartData.info;
 
   const { user } = useContext(NavbarContext).userState;
-  console.log("chartData: ", user.metric);
   //object with all statistics for user clusters
   const rawMetric = user.metric;
 
   //stats for aggregated charts
   const aggStats = {
-    active_connection_count: "",
-    partition_count: "",
-    successful_authentication_count: "",
-    cluster_load_percent: ""
+    active_connection_count: { label: "Active Connection Count", data: {} },
+    partition_count: { label: "Partition Count", data: {} },
+    successful_authentication_count: {
+      label: "Successful Authentication Count",
+      data: {}
+    },
+    cluster_load_percent: { label: "Cluster Load Percent", data: {} }
   };
 
   //dataset creation for charts
@@ -59,17 +61,15 @@ const AggregatedChart = (props) => {
         }
       }
     }
-    aggStats[stat] = data;
+    aggStats[stat].data = data;
   }
-
-  console.log("data: ", aggStats);
 
   //creating aggregated charts
   const charts = [];
   for (const stat in aggStats) {
     const chart = (
-      <div className="topic-chart font-mono chart-container pb-10">
-        <p style={{ fontSize: "18px" }}>{stat}</p>
+      <div className="topic-chart font-mono chart-container pb-24">
+        <p style={{ fontSize: "18px" }}>{aggStats[stat].label}</p>
 
         <br />
         <Line
@@ -77,14 +77,14 @@ const AggregatedChart = (props) => {
           options={{
             maintainAspectRatio: false
           }}
-          data={aggStats[stat]}
+          data={aggStats[stat].data}
         />
       </div>
     );
     charts.push(chart);
   }
 
-  return <>{charts}</>;
+  return <div className="grid grid-cols-2 pb-8">{charts}</div>;
 };
 
 export default AggregatedChart;

--- a/client/components/aggregated-chart.jsx
+++ b/client/components/aggregated-chart.jsx
@@ -4,23 +4,6 @@ import "chart.js/auto";
 import { Bar, Line } from "react-chartjs-2";
 
 const AggregatedChart = (props) => {
-  //metric selection and context state
-  const { setMetric } = useContext(NavbarContext).metricState;
-  const { sideBarMode } = useContext(NavbarContext).sideBarState;
-
-  async function updateMetrics() {
-    const response = await fetch("/api/metric");
-    const metric = await response.json();
-
-    setMetric(metric);
-  }
-
-  // selecting metric specific to this chart
-  const metric = props.metricSelection;
-  const chartData = props.chartData[metric];
-
-  const data = chartData.info;
-
   const { user } = useContext(NavbarContext).userState;
   //object with all statistics for user clusters
   const rawMetric = user.metric;
@@ -31,57 +14,59 @@ const AggregatedChart = (props) => {
     partition_count: { label: "Partition Count", data: {} },
     successful_authentication_count: {
       label: "Successful Authentication Count",
-      data: {}
+      data: { labels: [], datasets: [] }
     },
     cluster_load_percent: { label: "Cluster Load Percent", data: {} }
   };
 
-  //dataset creation for charts
-  for (const stat in aggStats) {
-    const data = { labels: [], datasets: [] };
-    let statArr = [];
-    const labels = [];
-    let curr = rawMetric[0].clusterId;
-    for (let i = 0; i < rawMetric.length; i++) {
-      data.labels.push(rawMetric[i].created_at);
-      statArr.push({
-        x: i,
-        //edge case where some of the arrays were empty
-        y: rawMetric[i][stat].metrics.length
-          ? rawMetric[i][stat].metrics[0].value
-          : 0
-      });
-      if (i + 1 === rawMetric.length || rawMetric[i + 1].clusterId !== curr) {
-        const metricObj = { label: curr, data: statArr };
-        data.labels.sort();
-        data.datasets.push(metricObj);
-        if (i + 1 !== rawMetric.length) {
-          statArr = [];
-          curr = rawMetric[i + 1].clusterId;
+  const charts = [];
+  //condition to prevent crashing due to empty data in user profile
+  if (rawMetric.length) {
+    //dataset creation for charts
+    for (const stat in aggStats) {
+      const data = { labels: [], datasets: [] };
+      let statArr = [];
+      const labels = [];
+      let curr = rawMetric[0].clusterId;
+      for (let i = 0; i < rawMetric.length; i++) {
+        data.labels.push(rawMetric[i].created_at);
+        statArr.push({
+          x: i,
+          //edge case where some of the arrays were empty
+          y: rawMetric[i][stat].metrics.length
+            ? rawMetric[i][stat].metrics[0].value
+            : 0
+        });
+        if (i + 1 === rawMetric.length || rawMetric[i + 1].clusterId !== curr) {
+          const metricObj = { label: curr, data: statArr };
+          data.labels.sort();
+          data.datasets.push(metricObj);
+          if (i + 1 !== rawMetric.length) {
+            statArr = [];
+            curr = rawMetric[i + 1].clusterId;
+          }
         }
       }
+      aggStats[stat].data = data;
     }
-    aggStats[stat].data = data;
-  }
+    //creating aggregated charts
+    for (const stat in aggStats) {
+      const chart = (
+        <div className="topic-chart font-mono chart-container pb-24">
+          <p style={{ fontSize: "18px" }}>{aggStats[stat].label}</p>
 
-  //creating aggregated charts
-  const charts = [];
-  for (const stat in aggStats) {
-    const chart = (
-      <div className="topic-chart font-mono chart-container pb-24">
-        <p style={{ fontSize: "18px" }}>{aggStats[stat].label}</p>
-
-        <br />
-        <Line
-          type={"line"}
-          options={{
-            maintainAspectRatio: false
-          }}
-          data={aggStats[stat].data}
-        />
-      </div>
-    );
-    charts.push(chart);
+          <br />
+          <Line
+            type={"line"}
+            options={{
+              maintainAspectRatio: false
+            }}
+            data={aggStats[stat].data}
+          />
+        </div>
+      );
+      charts.push(chart);
+    }
   }
 
   return <div className="grid grid-cols-2 pb-8">{charts}</div>;

--- a/client/components/chart.jsx
+++ b/client/components/chart.jsx
@@ -22,16 +22,6 @@ const Chart = (props) => {
 
   return (
     <div className="topic-chart font-mono chart-container">
-      <div className="flex">
-        {sideBarMode === "current" && (
-          <>
-            <button onClick={updateMetrics} className="mb-5 btn bg-blue-800">
-              Update Metrics
-            </button>
-          </>
-        )}
-      </div>
-
       <p style={{ fontSize: "18px" }}>{chartData.colDescription}</p>
 
       <br />

--- a/client/components/cluster-item.jsx
+++ b/client/components/cluster-item.jsx
@@ -13,7 +13,7 @@ const ClusterItem = (props) => {
   }
 
   return (
-    <tr className="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600">
+    <tr className="bg-white border-b  hover:bg-gray-50">
       <td>{index}</td>
       <td>{date}</td>
       <td>{clusterId}</td>

--- a/client/components/footer.jsx
+++ b/client/components/footer.jsx
@@ -16,38 +16,62 @@ const Footer = () => {
         <div>
           <span className="footer-title">Social</span>
           <div className="grid grid-flow-col gap-4">
-            <a>
+            <a
+              href="https://www.linkedin.com/company/kafkacompass/"
+              target="_blank"
+            >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
+                aria-label="LinkedIn"
+                role="img"
                 width="24"
                 height="24"
-                viewBox="0 0 24 24"
-                className="fill-current"
+                viewBox="0 0 512 512"
+                fill="#fff"
+                className="hover:scale-110 transition duration-300 ease-in-out"
               >
-                <path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"></path>
+                <rect width="512" height="512" rx="15%" fill="#0077b5" />
+                <circle cx="142" cy="138" r="37" />
+                <path
+                  stroke="#fff"
+                  stroke-width="66"
+                  d="M244 194v198M142 194v198"
+                />
+                <path d="M276 282c0-20 13-40 36-40 24 0 33 18 33 45v105h66V279c0-61-32-89-76-89-34 0-51 19-59 32" />
               </svg>
             </a>
-            <a>
+            <a
+              href="https://medium.com/@daria.mordvinov/dont-get-lost-while-working-with-your-kafka-clusters-grab-a-compass-dff330bf387e"
+              target="_blank"
+            >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
+                aria-label="Medium"
+                role="img"
                 width="24"
                 height="24"
-                viewBox="0 0 24 24"
-                className="fill-current"
-                onClick={() => console.log("clicked")}
+                viewBox="0 0 512 512"
+                className="hover:scale-110 transition duration-300 ease-in-out"
               >
-                <path d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z"></path>
+                <rect width="512" height="512" rx="15%" fill="#12100e" />
+                <path
+                  fill="#fff"
+                  d="M125 173c0-4-2-9-5-11l-31-38v-6h98l75 166 67-166h93v6l-27 26c-2 1-3 4-3 7v190c0 3 1 6 3 8l27 25v6H289v-6l27-26c3-3 3-4 3-8V193l-76 192h-10l-88-192v129c-1 5 1 11 5 15l35 43v5H85v-5l35-43c4-4 6-10 5-15z"
+                />
               </svg>
             </a>
-            <a>
+            <a href="https://angel.co/company/kafkacompass" target="_blank">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
+                aria-label="AngelList"
+                role="img"
                 width="24"
                 height="24"
-                viewBox="0 0 24 24"
-                className="fill-current"
+                viewBox="0 0 512 512"
+                className="hover:scale-110 transition duration-300 ease-in-out"
               >
-                <path d="M9 8h-3v4h3v12h5v-12h3.642l.358-4h-4v-1.667c0-.955.192-1.333 1.115-1.333h2.885v-5h-3.808c-3.596 0-5.192 1.583-5.192 4.615v3.385z"></path>
+                <rect width="512" height="512" rx="15%" fill="#fff" />
+                <path d="M342 230c39 4 47 43 47 75 0 65-33 128-95 154-51 21-114 13-155-25-25-22-39-51-40-84 0-30 15-49 44-57-3-8-9-19-9-28 0-18 20-40 38-40 9 0 17 3 24 8-15-58-75-175-5-181 34-3 69 125 78 153 11-26 45-145 80-145 66 0 7 130-7 170zM138 348c13 13 22 41 45 41 29-3-18-76-39-76-17 0-26 21-26 36 0 38 31 74 65 89 50 23 111 12 149-29 33-37 43-88 34-136-3-24-35-29-54-33-23-6-47-8-71-8-30 0-17 36 3 44 26 9 55 9 83 9 6 0 9 6 9 12-13 10-30 13-43 23a79 79 0 00-34 86c2 7 4 14 4 21-26 0-27-37-27-54-5 5-13 4-20 3 4 18-5 38-27 38-24 0-55-26-55-52 0-4 1-11 4-14zm86 6c35 0-8-67-15-77-10-17-28-38-46-20s7 50 19 65c10 14 23 32 42 32zm28-140l-32-87c-4-12-18-56-32-56-26 0-7 51-4 62 7 22 17 51 31 85 10-7 26-6 37-4zm32 88c-15 0-32-2-45-8 5 13 10 24 13 38 9-12 20-22 32-30zm39-77c13-34 22-64 30-86 3-10 22-59-1-59-17 0-32 43-36 56l-29 82 36 7z" />
               </svg>
             </a>
           </div>

--- a/client/components/footer.jsx
+++ b/client/components/footer.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+import logoWithoutText from "../static/logo_without_text.png";
+
+const Footer = () => {
+  return (
+    <>
+      <footer className="footer p-10 bg-gray-700 text-neutral-content mt-auto">
+        <div>
+          <img className="h-12" src={logoWithoutText} alt="Kafka logo" />
+          <p>
+            KafkaCompass
+            <br />
+            An open source tool for monitoring your Kafka clusters
+          </p>
+        </div>
+        <div>
+          <span className="footer-title">Social</span>
+          <div className="grid grid-flow-col gap-4">
+            <a>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                className="fill-current"
+              >
+                <path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"></path>
+              </svg>
+            </a>
+            <a>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                className="fill-current"
+                onClick={() => console.log("clicked")}
+              >
+                <path d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z"></path>
+              </svg>
+            </a>
+            <a>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                className="fill-current"
+              >
+                <path d="M9 8h-3v4h3v12h5v-12h3.642l.358-4h-4v-1.667c0-.955.192-1.333 1.115-1.333h2.885v-5h-3.808c-3.596 0-5.192 1.583-5.192 4.615v3.385z"></path>
+              </svg>
+            </a>
+          </div>
+        </div>
+      </footer>
+    </>
+  );
+};
+
+export default Footer;

--- a/client/components/nav-bar.jsx
+++ b/client/components/nav-bar.jsx
@@ -10,6 +10,9 @@ const Navbar = ({ navigate, logUserOut }) => {
   // dictates the view mode on dashbaord
   const { dashboardMode, setDashboardMode } =
     useContext(NavbarContext).dashboardState;
+  // modifies the performance mode menu in the case of looking at historical metrics
+  const { sideBarMode, setSideBarMode } =
+    useContext(NavbarContext).sideBarState;
   // functions for switching mode of the dashboard
   function changeModePerformanceStatistics() {
     setDashboardMode("performanceStatistics");
@@ -49,12 +52,9 @@ const Navbar = ({ navigate, logUserOut }) => {
                 ? " bg-blue-800 text-white"
                 : ""
             }
+            onClick={changeModePerformanceStatistics}
           >
-            <a>
-              <label onClick={changeModePerformanceStatistics}>
-                Performance Statistics
-              </label>
-            </a>
+            <a>Performance Statistics</a>
           </li>
           <li
             className={
@@ -62,12 +62,18 @@ const Navbar = ({ navigate, logUserOut }) => {
                 ? " bg-blue-800 text-white"
                 : ""
             }
+            onClick={changeModeContentMonitoring}
           >
-            <a>
-              <label onClick={changeModeContentMonitoring}>
-                Content Monitoring
-              </label>
-            </a>
+            <a>Content Monitoring</a>
+          </li>
+          <li
+            key="Cluster History"
+            onClick={() => {
+              setSideBarMode("history");
+              setDashboardMode("clusterHistory");
+            }}
+          >
+            <a>Cluster History</a>
           </li>
           <b>Cluster Options</b>
           <li>

--- a/client/components/nav-bar.jsx
+++ b/client/components/nav-bar.jsx
@@ -7,6 +7,16 @@ const Navbar = ({ navigate, logUserOut }) => {
   const { renderDrawerButton, setRenderDrawerButton } =
     useContext(NavbarContext).drawerButtonsState;
   const { loggedIn, setLoggedIn } = useContext(NavbarContext).loggedState;
+  // dictates the view mode on dashbaord
+  const { dashboardMode, setDashboardMode } =
+    useContext(NavbarContext).dashboardState;
+  // functions for switching mode of the dashboard
+  function changeModePerformanceStatistics() {
+    setDashboardMode("performanceStatistics");
+  }
+  function changeModeContentMonitoring() {
+    setDashboardMode("contentMonitoring");
+  }
 
   let drawerButtons = <></>;
 
@@ -32,11 +42,34 @@ const Navbar = ({ navigate, logUserOut }) => {
           tabIndex={0}
           className="menu menu-compact dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-52 text-black"
         >
-          <li>
+          <b>View Modes</b>
+          <li
+            className={
+              dashboardMode === "performanceStatistics"
+                ? " bg-blue-800 text-white"
+                : ""
+            }
+          >
             <a>
-              <label htmlFor="my-drawer">Select Metrics</label>
+              <label onClick={changeModePerformanceStatistics}>
+                Performance Statistics
+              </label>
             </a>
           </li>
+          <li
+            className={
+              dashboardMode === "contentMonitoring"
+                ? " bg-blue-800 text-white"
+                : ""
+            }
+          >
+            <a>
+              <label onClick={changeModeContentMonitoring}>
+                Content Monitoring
+              </label>
+            </a>
+          </li>
+          <b>Cluster Options</b>
           <li>
             <a>
               <label htmlFor="my-modal-4">Add New Cluster</label>

--- a/client/components/performance-statistics.jsx
+++ b/client/components/performance-statistics.jsx
@@ -1,0 +1,112 @@
+import React, { useState, useContext } from "react";
+import { NavbarContext } from "../NavbarContext";
+import TableData from "../components/table-data";
+import Chart from "../components/chart";
+
+const PerformanceStatistics = ({
+  chartData,
+  metricSelection,
+  tableData,
+  updateSideDrawer
+}) => {
+  const { setMetric } = useContext(NavbarContext).metricState;
+  async function updateMetrics() {
+    console.log("doing the thing");
+    const response = await fetch("/api/metric");
+    const metric = await response.json();
+
+    setMetric(metric);
+  }
+
+  const { sideBarMode, setSideBarMode } =
+    useContext(NavbarContext).sideBarState;
+  const { setDashboardMode } = useContext(NavbarContext).dashboardState;
+  const { metricIndex, setMetricIndex } =
+    useContext(NavbarContext).metricIndexState;
+
+  const choices = {
+    retained_bytes: "Retained Bytes",
+    sent_bytes: "Sent Bytes",
+    received_records: "Received Records",
+    sent_records: "Sent Records",
+    request_bytes: "Request Bytes",
+    response_bytes: "Response Bytes",
+    request_count: "Request Counts",
+    req_res: "Request/Response bytes"
+  };
+
+  const listItems = Object.keys(choices).map((key) => (
+    <li
+      key={key}
+      onClick={() => {
+        updateSideDrawer(key);
+        // if we switched to history mode but have not choosen the snapshot,
+        // and now we whant to back to the chart on current cluster
+        if (sideBarMode === "history" && metricIndex === -1) {
+          setSideBarMode("current");
+          setDashboardMode("performanceStatistics");
+        }
+      }}
+      className={metricSelection === key ? "bg-blue-800 text-white" : ""}
+    >
+      <a>{choices[key]}</a>
+    </li>
+  ));
+
+  return (
+    <>
+      <div class="grid grid-cols-6">
+        <div className="border">
+          <ul class="menu border bg-base-100 menu-compact lg:menu-normal">
+            <b>Metrics</b>
+            {listItems}
+            <li>
+              <a>
+                <label onClick={updateMetrics}>
+                  <b>Update Metrics</b>
+                </label>
+              </a>
+            </li>
+            <li
+              key="Cluster History"
+              onClick={() => {
+                setSideBarMode("history");
+                setDashboardMode("clusterHistory");
+              }}
+            >
+              <a>
+                <b>Cluster History</b>
+              </a>
+            </li>
+            {sideBarMode === "history" && (
+              <li
+                key="Current Metric"
+                onClick={() => {
+                  setSideBarMode("current");
+                  setDashboardMode("performanceStatistics");
+                  setMetricIndex(-1);
+                }}
+              >
+                <a>
+                  <b>Back to current cluster</b>
+                </a>
+              </li>
+            )}
+          </ul>
+        </div>
+        <div className="border col-span-3">
+          {chartData && (
+            <>
+              <Chart chartData={chartData} metricSelection={metricSelection} />
+            </>
+          )}
+        </div>
+        <div className="border col-span-2">
+          <TableData tableData={tableData} />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default PerformanceStatistics;

--- a/client/components/performance-statistics.jsx
+++ b/client/components/performance-statistics.jsx
@@ -7,7 +7,8 @@ const PerformanceStatistics = ({
   chartData,
   metricSelection,
   tableData,
-  updateSideDrawer
+  updateSideDrawer,
+  clusterId
 }) => {
   const { setMetric } = useContext(NavbarContext).metricState;
   async function updateMetrics() {
@@ -95,6 +96,9 @@ const PerformanceStatistics = ({
           </ul>
         </div>
         <div className="border col-span-3">
+          <h1 className="flex justify-around font-bold text-xl pb-5">
+            Cluster: {clusterId}
+          </h1>
           {chartData && (
             <>
               <Chart chartData={chartData} metricSelection={metricSelection} />

--- a/client/components/performance-statistics.jsx
+++ b/client/components/performance-statistics.jsx
@@ -61,7 +61,7 @@ const PerformanceStatistics = ({
         <div className="border">
           <ul class="menu border bg-base-100 menu-compact lg:menu-normal h-screen">
             <span className="pl-4">
-              <b>Metrics</b>
+              <b>Metric Views</b>
             </span>
             {listItems}
             <li>
@@ -99,7 +99,14 @@ const PerformanceStatistics = ({
           </ul>
         </div>
         <div className="border col-span-3">
-          <h1 className="flex justify-around text-xl pb-5">
+          <table className="table w-full">
+            <thead>
+              <th className="flex justify-around text-l">
+                <b>Performance Statistics</b>
+              </th>
+            </thead>
+          </table>
+          <h1 className="flex justify-around text-xl pb-5 pt-5">
             <b>Cluster: {clusterId}</b> <b>Snapshot: {snapshotTime}</b>
           </h1>
           {chartData && (

--- a/client/components/performance-statistics.jsx
+++ b/client/components/performance-statistics.jsx
@@ -13,7 +13,6 @@ const PerformanceStatistics = ({
 }) => {
   const { setMetric } = useContext(NavbarContext).metricState;
   async function updateMetrics() {
-    console.log("doing the thing");
     const response = await fetch("/api/metric");
     const metric = await response.json();
 
@@ -69,17 +68,6 @@ const PerformanceStatistics = ({
                 <label onClick={updateMetrics}>
                   <b>Update Metrics</b>
                 </label>
-              </a>
-            </li>
-            <li
-              key="Cluster History"
-              onClick={() => {
-                setSideBarMode("history");
-                setDashboardMode("clusterHistory");
-              }}
-            >
-              <a>
-                <b>Cluster History</b>
               </a>
             </li>
             {sideBarMode === "history" && (

--- a/client/components/performance-statistics.jsx
+++ b/client/components/performance-statistics.jsx
@@ -59,8 +59,8 @@ const PerformanceStatistics = ({
     <>
       <div class="grid grid-cols-6">
         <div className="border">
-          <ul class="menu border bg-base-100 menu-compact lg:menu-normal h-screen">
-            <span className="pl-4">
+          <ul class="menu border bg-base-100 menu-compact lg:menu-normal h-screen bg-slate-100">
+            <span className="pl-4 pt-3 pb-3">
               <b>Metric Views</b>
             </span>
             {listItems}

--- a/client/components/performance-statistics.jsx
+++ b/client/components/performance-statistics.jsx
@@ -8,7 +8,8 @@ const PerformanceStatistics = ({
   metricSelection,
   tableData,
   updateSideDrawer,
-  clusterId
+  clusterId,
+  snapshotTime
 }) => {
   const { setMetric } = useContext(NavbarContext).metricState;
   async function updateMetrics() {
@@ -58,8 +59,10 @@ const PerformanceStatistics = ({
     <>
       <div class="grid grid-cols-6">
         <div className="border">
-          <ul class="menu border bg-base-100 menu-compact lg:menu-normal">
-            <b>Metrics</b>
+          <ul class="menu border bg-base-100 menu-compact lg:menu-normal h-screen">
+            <span className="pl-4">
+              <b>Metrics</b>
+            </span>
             {listItems}
             <li>
               <a>
@@ -96,8 +99,8 @@ const PerformanceStatistics = ({
           </ul>
         </div>
         <div className="border col-span-3">
-          <h1 className="flex justify-around font-bold text-xl pb-5">
-            Cluster: {clusterId}
+          <h1 className="flex justify-around text-xl pb-5">
+            <b>Cluster: {clusterId}</b> <b>Snapshot: {snapshotTime}</b>
           </h1>
           {chartData && (
             <>

--- a/client/components/table-data.jsx
+++ b/client/components/table-data.jsx
@@ -7,9 +7,6 @@ const TableData = (props) => {
     oneRow = (
       <tr key={row.name}>
         <td>{row.name}</td>
-        <td>
-          <div className="scrollable">{row.description}</div>
-        </td>
         <td>{row.value}</td>
       </tr>
     );
@@ -17,13 +14,12 @@ const TableData = (props) => {
   }
 
   return (
-    <div className="table-stats">
+    <div className="">
       <div className="overflow-x-auto">
         <table className="table w-full">
           <thead>
             <tr>
               <th>Name</th>
-              <th>Description</th>
               <th>Metrics</th>
             </tr>
           </thead>

--- a/client/components/table-data.jsx
+++ b/client/components/table-data.jsx
@@ -19,8 +19,8 @@ const TableData = (props) => {
         <table className="table w-full">
           <thead>
             <tr>
-              <th>Name</th>
-              <th>Metrics</th>
+              <th>Metric</th>
+              <th>Value</th>
             </tr>
           </thead>
           <tbody>{tableRows}</tbody>

--- a/client/containers/cluster-history.jsx
+++ b/client/containers/cluster-history.jsx
@@ -45,7 +45,7 @@ const ClusterHistory = ({ chartData }) => {
         <div className="table-history">
           <div className="overflow-x-auto shadow-md sm:rounded-lg">
             <table className="history-table table-compact w-auto">
-              <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+              <thead className="text-xs text-gray-700 uppercase bg-gray-50">
                 <tr>
                   <th></th>
                   <th>Date</th>

--- a/client/containers/cluster-history.jsx
+++ b/client/containers/cluster-history.jsx
@@ -58,8 +58,6 @@ const ClusterHistory = ({ chartData }) => {
           </div>
         </div>
       </div>
-      <input type="checkbox" id="my-modal-4" className="modal-toggle" />
-      <AddClusterForm />
     </>
   );
 };

--- a/client/containers/cluster-history.jsx
+++ b/client/containers/cluster-history.jsx
@@ -34,17 +34,20 @@ const ClusterHistory = ({ chartData }) => {
   return (
     <>
       <div>
+        <h1 className="text-center text-2xl font-bold pb-10">
+          Cluster History
+        </h1>
         <AggregatedChart
           chartData={chartData}
           metricSelection={metricSelection}
         />
-        <h1 className="text-center text-xl font-bold">Cluster History</h1>
+        <h1 className="text-center text-xl font-bold">Snapshots</h1>
         <div className="table-history">
           <div className="overflow-x-auto shadow-md sm:rounded-lg">
             <table className="history-table table-compact w-auto">
               <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
                 <tr>
-                  <th>Cluster Index</th>
+                  <th></th>
                   <th>Date</th>
                   <th>Cluster Id:</th>
                   <th>View Metrics</th>

--- a/client/containers/cluster-history.jsx
+++ b/client/containers/cluster-history.jsx
@@ -28,8 +28,8 @@ const ClusterHistory = ({ chartData }) => {
     );
   });
 
-  //temp
-  const [metricSelection, setMetricSelection] = useState("retained_bytes");
+  // //temp
+  // const [metricSelection, setMetricSelection] = useState("retained_bytes");
 
   return (
     <>
@@ -37,10 +37,7 @@ const ClusterHistory = ({ chartData }) => {
         <h1 className="text-center text-2xl font-bold pb-10">
           Cluster History
         </h1>
-        <AggregatedChart
-          chartData={chartData}
-          metricSelection={metricSelection}
-        />
+        <AggregatedChart chartData={chartData} />
         <h1 className="text-center text-xl font-bold">Snapshots</h1>
         <div className="table-history">
           <div className="overflow-x-auto shadow-md sm:rounded-lg">

--- a/client/containers/cluster-history.jsx
+++ b/client/containers/cluster-history.jsx
@@ -1,10 +1,11 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import AddClusterForm from "../components/add-cluster-form";
 import ClusterItem from "../components/cluster-item";
+import AggregatedChart from "../components/aggregated-chart";
 import { NavbarContext } from "../NavbarContext";
 
-const ClusterHistory = (props) => {
+const ClusterHistory = ({ chartData }) => {
   const navigate = useNavigate();
   const metrics = useContext(NavbarContext).userState.user.metric;
   const { setRenderDrawerButton } =
@@ -27,11 +28,17 @@ const ClusterHistory = (props) => {
     );
   });
 
+  //temp
+  const [metricSelection, setMetricSelection] = useState("retained_bytes");
+
   return (
     <>
       <div>
+        <AggregatedChart
+          chartData={chartData}
+          metricSelection={metricSelection}
+        />
         <h1 className="text-center text-xl font-bold">Cluster History</h1>
-
         <div className="table-history">
           <div className="overflow-x-auto shadow-md sm:rounded-lg">
             <table className="history-table table-compact w-auto">

--- a/client/containers/dashboard-container.jsx
+++ b/client/containers/dashboard-container.jsx
@@ -17,7 +17,9 @@ const DashboardContainer = (props) => {
 
   // cluster selection for the Content Monitoring
   const [cluster, setCluster] = useState(0);
-  const [clusterId, setClusterId] = useState();
+  // current cluster information
+  const [clusterId, setClusterId] = useState("");
+  const [snapshotTime, setSnapshotTime] = useState("");
 
   // Setting document's background image back to none -> default
   document.body.style.backgroundImage = "none";
@@ -66,6 +68,7 @@ const DashboardContainer = (props) => {
       setTableData(dataForTable);
       setChart(mapChartData(data));
       setClusterId(data.clusterId);
+      setSnapshotTime(data.created_at);
     } catch {
       console.log("No clusters in user data");
     }
@@ -107,6 +110,7 @@ const DashboardContainer = (props) => {
           tableData={tableData}
           updateSideDrawer={updateSideDrawer}
           clusterId={clusterId}
+          snapshotTime={snapshotTime}
         />
       </>
     );

--- a/client/containers/dashboard-container.jsx
+++ b/client/containers/dashboard-container.jsx
@@ -8,6 +8,7 @@ import DrawerSide from "../components/drawer-side";
 import mapChartData from "../helper/mapChartData";
 import ClusterHistory from "./cluster-history";
 import SwitchCluster from "../components/switch-cluster-form";
+import PerformanceStatistics from "../components/performance-statistics";
 
 const DashboardContainer = (props) => {
   // state of current topic inside the Content Monitoring view
@@ -77,19 +78,26 @@ const DashboardContainer = (props) => {
     setDashboardMode("contentMonitoring");
   }
 
+  const { setMetric } = useContext(NavbarContext).metricState;
+  async function updateMetrics() {
+    console.log("doing the thing");
+    const response = await fetch("/api/metric");
+    const metric = await response.json();
+
+    setMetric(metric);
+  }
+
   // sets current dashboard view
   let dashboardView = <></>;
   if (dashboardMode === "performanceStatistics") {
     dashboardView = (
       <>
-        <main className="cluster-container">
-          {chartData && (
-            <>
-              <Chart chartData={chartData} metricSelection={metricSelection} />
-            </>
-          )}
-        </main>
-        <TableData tableData={tableData} />
+        <PerformanceStatistics
+          chartData={chartData}
+          metricSelection={metricSelection}
+          tableData={tableData}
+          updateSideDrawer={updateSideDrawer}
+        />
       </>
     );
   } else if (dashboardMode === "contentMonitoring") {
@@ -109,57 +117,16 @@ const DashboardContainer = (props) => {
 
   return (
     <>
-      <div className="drawer">
-        <input id="my-drawer" type="checkbox" className="drawer-toggle" />
-        <div className="drawer-content border-solid border-2 border-black-500">
-          <div className="mt-4 flex justify-around">
-            {sideBarMode != "history" && (
-              <div className="btn-group">
-                <button
-                  className={
-                    dashboardMode === "performanceStatistics"
-                      ? "btn bg-blue-800"
-                      : "btn"
-                  }
-                  onClick={changeModePerformanceStatistics}
-                >
-                  Performance Statistics
-                </button>
-                <button
-                  className={
-                    dashboardMode === "contentMonitoring"
-                      ? "btn bg-blue-800"
-                      : "btn"
-                  }
-                  onClick={changeModeContentMonitoring}
-                >
-                  Content Monitoring
-                </button>
-                {/* Feature in work
-                <button
-                  className={
-                    dashboardMode === "clusterComparison"
-                      ? "btn btn-accent"
-                      : "btn"
-                  }
-                  onClick={changeModeClusterComparison}
-                >
-                  Cluster Comparison
-                </button> */}
-              </div>
-            )}
-          </div>
-          <div className="justify-center pt-10">{dashboardView}</div>
-        </div>
-        <AddClusterForm
-          clusterAdded={clusterAdded}
-          setClusterAdded={setClusterAdded}
-        />
-        <DrawerSide
-          metricSelection={metricSelection}
-          updateSideDrawer={updateSideDrawer}
-        />
-      </div>
+      <div className="justify-center h-screen">{dashboardView}</div>
+      <AddClusterForm
+        clusterAdded={clusterAdded}
+        setClusterAdded={setClusterAdded}
+      />
+      {/* <DrawerSide
+        metricSelection={metricSelection}
+        updateSideDrawer={updateSideDrawer}
+      /> */}
+
       <SwitchCluster
         cluster={cluster}
         setCluster={setCluster}

--- a/client/containers/dashboard-container.jsx
+++ b/client/containers/dashboard-container.jsx
@@ -17,6 +17,7 @@ const DashboardContainer = (props) => {
 
   // cluster selection for the Content Monitoring
   const [cluster, setCluster] = useState(0);
+  const [clusterId, setClusterId] = useState();
 
   // Setting document's background image back to none -> default
   document.body.style.backgroundImage = "none";
@@ -42,7 +43,15 @@ const DashboardContainer = (props) => {
         "partition_count",
         "active_connection_count",
         "successful_authentication_count",
-        "cluster_load_percent"
+        "cluster_load_percent",
+        "consumer_lag_offsets",
+        "received_bytes",
+        "received_records",
+        "request_bytes",
+        "request_count",
+        "retained_bytes",
+        "sent_bytes",
+        "sent_records"
       ].map((td) => {
         const name = td.replace(/_/g, " ");
         const description = data[td].description;
@@ -55,8 +64,8 @@ const DashboardContainer = (props) => {
       });
 
       setTableData(dataForTable);
-
       setChart(mapChartData(data));
+      setClusterId(data.clusterId);
     } catch {
       console.log("No clusters in user data");
     }
@@ -97,6 +106,7 @@ const DashboardContainer = (props) => {
           metricSelection={metricSelection}
           tableData={tableData}
           updateSideDrawer={updateSideDrawer}
+          clusterId={clusterId}
         />
       </>
     );

--- a/client/containers/dashboard-container.jsx
+++ b/client/containers/dashboard-container.jsx
@@ -131,7 +131,7 @@ const DashboardContainer = (props) => {
 
   return (
     <>
-      <div className="justify-center h-screen">{dashboardView}</div>
+      <div className="justify-center">{dashboardView}</div>
       <AddClusterForm
         clusterAdded={clusterAdded}
         setClusterAdded={setClusterAdded}

--- a/client/containers/dashboard-container.jsx
+++ b/client/containers/dashboard-container.jsx
@@ -107,7 +107,7 @@ const DashboardContainer = (props) => {
       </div>
     );
   } else if (dashboardMode === "clusterHistory") {
-    dashboardView = <ClusterHistory />;
+    dashboardView = <ClusterHistory chartData={chartData} />;
   }
 
   // update metrics object with desired viewing metrics

--- a/client/helper/mapChartData.js
+++ b/client/helper/mapChartData.js
@@ -1,5 +1,4 @@
 function mapChartData(data) {
-  console.log(data);
   const metricsObj = {
     retained_bytes: {
       colDescription: "Topics in Cluster",
@@ -65,8 +64,6 @@ function mapChartData(data) {
     },
     compositeChart: true
   };
-
-  console.log(metricsObj);
 
   return metricsObj;
 }

--- a/client/static/styles.css
+++ b/client/static/styles.css
@@ -112,9 +112,9 @@ article {
 }
 
 .chart-container {
-  grid-column-start: 3;
+  /* grid-column-start: 3;
   display: flex;
-  flex-direction: column;
+  flex-direction: column; */
   align-items: center;
   text-align: center;
   height: 40vh;


### PR DESCRIPTION
- Refactored top left dashboard navigation to host switching of modes, instead of doing so on the actual dashboard view.  Now more of the dashboard space can be used for viewing metrics/cluster content
- Added charts on cluster history page for stats aggregated across snapshots
- Refactored the Performance Mode UI to a grid layout, with menu for switching charts now statically displayed on the left to make switching between charts faster and easier to navigate
- Added more statistics to Performance Mode view, including showing current cluster and snapshot time and moving the totals from the charts into the metrics table
- Added a footer with social media links to KafkaCompass pages
- Fixed a bug on the cluster history page where dark mode would make the snapshot table unreadable